### PR TITLE
Block archived ownable widget interactions

### DIFF
--- a/src/components/Ownable.tsx
+++ b/src/components/Ownable.tsx
@@ -38,7 +38,7 @@ export default function Ownable(props: OwnableProps) {
   }, [packages, packageCid, uniqueMessageHash]);
 
   const { iframeRef, info, metadata, isConsumed, isLocked, isTransferred, execute, onLoad } =
-    useOwnableState(chain, pkg, props.onError);
+    useOwnableState(chain, pkg, props.onError, !!props.archived);
 
   const { transfer } = useOwnableTransfer(chain, pkg, execute, props.onTransferred);
   const { showConfirm } = useDialogs();

--- a/src/hooks/useOwnableState.ts
+++ b/src/hooks/useOwnableState.ts
@@ -13,7 +13,8 @@ import { useProgress, LogProgress } from "@/contexts/Progress.context";
 export function useOwnableState(
   chain: EventChain,
   pkg: TypedPackage | undefined,
-  onError: (title: string, message: string) => void
+  onError: (title: string, message: string) => void,
+  archived = false
 ) {
   const ownables = useService("ownables");
   const eventChains = useService("eventChains");
@@ -111,6 +112,11 @@ export function useOwnableState(
   const execute = useCallback(
     async (msg: TypedDict, onProgress?: LogProgress, submitAnchors = true): Promise<void> => {
       if (!ownables) return;
+      if (archived) {
+        const message = "Archived ownables are read-only";
+        onError("Interaction unavailable", message);
+        throw new Error(message);
+      }
       try {
         const sd = await ownables.execute(chain, msg, stateDump, onProgress as any);
         if (submitAnchors) await ownables.submitAnchors(onProgress as any);
@@ -123,7 +129,7 @@ export function useOwnableState(
         throw e;
       }
     },
-    [chain, ownables, onError, refresh, stateDump]
+    [archived, chain, ownables, onError, refresh, stateDump]
   );
 
   const onLoad = useCallback(async (): Promise<void> => {
@@ -136,7 +142,6 @@ export function useOwnableState(
 
     try {
       await ownables.init(chain, pkg.cid, pkg.uniqueMessageHash);
-      ownables.setWidgetWindow(chain.id, iframeRef.current?.contentWindow ?? null);
       setInitialized(true);
     } catch (e) {
       onError("Failed to forge Ownable", ownableErrorMessage(e));
@@ -149,6 +154,10 @@ export function useOwnableState(
       if (!isObject(event.data) || !("ownable_id" in event.data) || event.data.ownable_id !== chain.id) return;
       if (iframeRef.current?.contentWindow !== event.source)
         throw Error("Not allowed to execute msg on other Ownable");
+      if (archived) {
+        onError("Interaction unavailable", "Archived ownables are read-only");
+        return;
+      }
 
       const steps = [{ id: "signEvent", label: "Sign the event" }];
       if (ownables?.anchoring) steps.push({ id: "anchor", label: "Anchor the event" });
@@ -161,7 +170,7 @@ export function useOwnableState(
         console.error("Widget action failed", e);
       }
     },
-    [chain.id, execute, progress, ownables]
+    [archived, chain.id, execute, progress, ownables, onError]
   );
 
   useEffect(() => {
@@ -173,6 +182,17 @@ export function useOwnableState(
   useEffect(() => {
     return () => { ownables?.setWidgetWindow(chain.id, null); };
   }, [chain.id, ownables]);
+
+  useEffect(() => {
+    if (!ownables) return;
+    if (archived) {
+      ownables.setWidgetWindow(chain.id, null);
+      return;
+    }
+    if (initialized) {
+      ownables.setWidgetWindow(chain.id, iframeRef.current?.contentWindow ?? null);
+    }
+  }, [archived, chain.id, initialized, ownables]);
 
   // Apply pending chain events and refresh
   const chainLatestHex = chain.latestHash.hex;

--- a/src/verification/main-list-discovery.verify.test.tsx
+++ b/src/verification/main-list-discovery.verify.test.tsx
@@ -624,6 +624,75 @@ describe("main-list discovery verifier", () => {
     );
   });
 
+  it("blocks archived ownable execution before reaching the runtime", async () => {
+    const chain = new EventChain(CHAIN_ID);
+    const onError = vi.fn();
+    const execute = vi.fn();
+
+    serviceMap.ownables = {
+      execute,
+      submitAnchors: vi.fn(),
+      rpc: vi.fn(),
+      setWidgetWindow: vi.fn(),
+    };
+    serviceMap.eventChains = {
+      getStateDump: vi.fn(),
+    };
+    serviceMap.eqty = {
+      address: "0xabc",
+    };
+
+    const { result } = renderHook(() =>
+      useOwnableState(chain, undefined, onError, true)
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.execute({ transfer: { to: "0xdef" } }, undefined, false)
+      ).rejects.toThrow("Archived ownables are read-only");
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      "Interaction unavailable",
+      "Archived ownables are read-only"
+    );
+  });
+
+  it("does not bind a widget window for archived ownables", async () => {
+    const chain = new EventChain(CHAIN_ID);
+    const onError = vi.fn();
+    const init = vi.fn().mockResolvedValue(undefined);
+    const setWidgetWindow = vi.fn();
+
+    serviceMap.ownables = {
+      init,
+      setWidgetWindow,
+    };
+
+    const { result } = renderHook(() =>
+      useOwnableState(
+        chain,
+        {
+          cid: "bafy",
+          uniqueMessageHash: "message-hash",
+          isDynamic: true,
+          title: "Archived ownable",
+          description: "desc",
+        } as any,
+        onError,
+        true
+      )
+    );
+
+    await act(async () => {
+      await result.current.onLoad();
+    });
+
+    expect(init).toHaveBeenCalledWith(chain, "bafy", "message-hash");
+    expect(setWidgetWindow).not.toHaveBeenCalledWith(chain.id, expect.anything());
+  });
+
   it("does not upload to Hub when transfer execution fails before upload", async () => {
     const user = userEvent.setup();
     const chain = new EventChain(CHAIN_ID);


### PR DESCRIPTION
## Summary
- treat archived ownables as read-only in the runtime path, not just the UI
- block widget-triggered execute calls for archived ownables
- avoid binding a live widget window for archived ownables
- add hook coverage for archived execute blocking and widget-window binding

## Verification
- `yarn build`
- `yarn test:e2e` (reports `0 scenarios`)
- `yarn verify:main-list-discovery` was started locally but did not complete in-session, so that check is still unverified